### PR TITLE
Presigned URL에 audio 업로드 지원 추가 (#6)

### DIFF
--- a/inpeak/build.gradle
+++ b/inpeak/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     // QueryDsl, spring boot 3.x 이상 세팅
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    implementation "com.querydsl:querydsl-core:5.0.0"
     annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
@@ -73,7 +74,7 @@ tasks.named('test', Test) {
 }
 
 // QueryDsl 빌드 옵션 (선택)
-def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+def querydslDir = "src/main/generated"
 
 sourceSets {
     main.java.srcDirs += [ querydslDir ]

--- a/inpeak/docker-compose.yml
+++ b/inpeak/docker-compose.yml
@@ -8,14 +8,11 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      redis:
-        condition: service_started
     environment:
       - SPRING_PROFILES_ACTIVE=local
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/inpeak-db
       - SPRING_DATASOURCE_USERNAME=myuser
       - SPRING_DATASOURCE_PASSWORD=secret
-      - SPRING_REDIS_HOST=redis
       - SECRET_KEY=your-secret-key-should-be-at-least-32-characters-long
       - REDIRECT_URL=http://localhost:5173
     networks:
@@ -44,13 +41,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-
-  redis:
-    image: redis:7.2
-    ports:
-      - "16379:6379"
-    networks:
-      - inpeak-net
 
 networks:
   inpeak-net:

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -88,10 +88,11 @@ public class AnswerController {
     public ResponseEntity<AnswerPresignedUrlResponse> getPresignedUrl(
         @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestParam LocalDate startDate,
-        @RequestParam String extension
+        @RequestParam(required = false) String extension,
+        @RequestParam Boolean includeVideo
     ) {
-        return ResponseEntity.ok(
-            answerPresignedUrlService.getPreSignedUrl(memberPrincipal.id(), startDate, extension));
+        return ResponseEntity.ok(answerService.getPresignedUrl(
+            memberPrincipal.id(), startDate, extension, includeVideo));
     }
 
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerPresignedUrlResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerPresignedUrlResponse.java
@@ -3,11 +3,15 @@ package com.blooming.inpeak.answer.dto.response;
 import lombok.Builder;
 
 @Builder
-public record AnswerPresignedUrlResponse(String url) {
+public record AnswerPresignedUrlResponse(
+    String audioUrl,
+    String videoUrl
+) {
 
-    public static AnswerPresignedUrlResponse of(String url) {
+    public static AnswerPresignedUrlResponse of(String audioUrl, String videoUrl) {
         return AnswerPresignedUrlResponse.builder()
-            .url(url)
+            .audioUrl(audioUrl)
+            .videoUrl(videoUrl)
             .build();
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
@@ -1,6 +1,5 @@
 package com.blooming.inpeak.answer.service;
 
-import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
 import com.blooming.inpeak.common.error.exception.BadRequestException;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -27,9 +26,8 @@ public class AnswerPresignedUrlService {
     private final S3Presigner s3Presigner;
 
     private static final Map<String, String> EXT_TO_CONTENT_TYPE = Map.of(
-        "mp4", "video/mp4",
-        "mov", "video/quicktime",
-        "webm", "video/webm"
+        "webm", "video/webm",
+        "wav", "audio/wav"
     );
 
     /**
@@ -37,11 +35,12 @@ public class AnswerPresignedUrlService {
      *
      * @param startDate 인터뷰 시작 날짜
      * @param extension 확장자 (예: "mp4")
+     * @param mediaType  "video" 또는 "audio"
      * @return Presigned URL
      */
-    public AnswerPresignedUrlResponse getPreSignedUrl(Long memberId, LocalDate startDate, String extension) {
+    public String getPreSignedUrl(Long memberId, LocalDate startDate, String extension, String mediaType) {
         // Object Key 생성
-        String key = generateObjectKey(memberId, startDate, extension);
+        String key = generateObjectKey(memberId, startDate, extension, mediaType);
 
         // 확장자에 따른 Content-Type 추출
         String contentType = extensionToContentType(extension);
@@ -56,7 +55,7 @@ public class AnswerPresignedUrlService {
         // Presigned URL 생성 요청 객체 생성
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
             .putObjectRequest(putObjectRequest)
-            .signatureDuration(Duration.ofMinutes(5)) // 만료 시간(5분)
+            .signatureDuration(Duration.ofMinutes(10)) // 만료 시간(10분)
             .build();
 
         // Presigned URL 생성
@@ -64,9 +63,7 @@ public class AnswerPresignedUrlService {
             s3Presigner.presignPutObject(presignRequest);
         s3Presigner.close();
 
-        String url = presignedPutObjectRequest.url().toString();
-
-        return AnswerPresignedUrlResponse.of(url);
+        return presignedPutObjectRequest.url().toString();
     }
 
     /**
@@ -77,11 +74,12 @@ public class AnswerPresignedUrlService {
      * @param extension 확장자 (예: "mp4")
      * @return "videos/123/250228/uuid.extension" 형태의 파일명
      */
-    private String generateObjectKey(Long memberId, LocalDate startDate, String extension) {
+    private String generateObjectKey(Long memberId, LocalDate startDate, String extension, String mediaType) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
         String dateString = startDate.format(formatter);
         String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
-        return String.format("videos/%d/%s/%s.%s", memberId, dateString, uuid, extension);
+
+        return String.format("%ss/%d/%s/%s.%s", mediaType, memberId, dateString, uuid, extension);
     }
 
     /**

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -7,6 +7,7 @@ import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
 import com.blooming.inpeak.answer.dto.response.AnswerDetailResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerIDResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
+import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerResponse;
 import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
@@ -45,6 +46,7 @@ public class AnswerService {
     private final QuestionRepository questionRepository;
     private final InterviewRepository interviewRepository;
     private final MemberStatisticsService memberStatisticsService;
+    private final AnswerPresignedUrlService answerPresignedUrlService;
 
     /**
      * 답변을 스킵하는 메서드
@@ -231,5 +233,27 @@ public class AnswerService {
         }
 
         return AnswerDetailResponse.from(answer);
+    }
+
+    /**
+     * 답변에 대한 presigned URL을 생성하는 메서드
+     *
+     * @param memberId    사용자 ID
+     * @param startDate   시작 날짜
+     * @param extension   비디오 확장자
+     * @param includeVideo 비디오 포함 여부
+     * @return presigned URL 응답 객체
+     */
+    public AnswerPresignedUrlResponse getPresignedUrl(Long memberId, LocalDate startDate,
+        String extension, Boolean includeVideo) {
+        String audioURL = answerPresignedUrlService.getPreSignedUrl(memberId, startDate, "wav",
+            "audio");
+        String videoURL = null;
+
+        if (includeVideo) {
+            videoURL = answerPresignedUrlService.getPreSignedUrl(memberId, startDate, extension,
+                "video");
+        }
+        return new AnswerPresignedUrlResponse(audioURL, videoURL);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #6 

## 📝 작업 내용

- presigned url 업로드 대상에 audio 파일 추가
- `docker-compose` Redis 관련 설정 제거
- QueryDSL 관련 설정 일부 개선

## 🎸 기타 (선택)


## 💬 리뷰 요구사항(선택)

