### PR TITLE
CompletableFuture 기반 GPT 응답 병렬 처리를 적용합니다

### DIFF
--- a/inpeak/build.gradle
+++ b/inpeak/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 
     // QueryDsl, spring boot 3.x 이상 세팅
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-    implementation "com.querydsl:querydsl-core:5.0.0"
     annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,8 +1,10 @@
 package com.blooming.inpeak.answer.controller;
 
 import com.blooming.inpeak.answer.domain.AnswerStatus;
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
 import com.blooming.inpeak.answer.dto.command.AnswerCreateCommand;
 import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
+import com.blooming.inpeak.answer.dto.request.AnswerCreateRequest;
 import com.blooming.inpeak.answer.dto.request.AnswerSkipRequest;
 import com.blooming.inpeak.answer.dto.request.CommentUpdateRequest;
 import com.blooming.inpeak.answer.dto.request.CorrectAnswerFilterRequest;
@@ -14,6 +16,7 @@ import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
 import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
+import com.blooming.inpeak.answer.service.AnswerAsyncService;
 import com.blooming.inpeak.answer.service.AnswerPresignedUrlService;
 import com.blooming.inpeak.answer.service.AnswerService;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
@@ -39,6 +42,7 @@ public class AnswerController {
 
     private final AnswerService answerService;
     private final AnswerPresignedUrlService answerPresignedUrlService;
+    private final AnswerAsyncService answerAsyncService;
 
     @PostMapping("/skip")
     public ResponseEntity<AnswerIDResponse> skipAnswer(
@@ -107,6 +111,17 @@ public class AnswerController {
         AnswerIDResponse response = answerService.createAnswer(
             AnswerCreateCommand.of(audioFile, time, memberPrincipal.id(),
                 questionId, interviewId, videoURL));
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/v2/create")
+    public ResponseEntity<Long> createAnswer(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @RequestBody AnswerCreateRequest request
+    ) {
+        AnswerCreateAsyncCommand command = request.toAsyncCommand(memberPrincipal.id());
+        Long response = answerAsyncService.requestAsyncAnswerCreation(command);
 
         return ResponseEntity.ok(response);
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -1,5 +1,6 @@
 package com.blooming.inpeak.answer.domain;
 
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
 import com.blooming.inpeak.answer.dto.command.AnswerCreateCommand;
 import com.blooming.inpeak.common.base.BaseEntity;
 import com.blooming.inpeak.interview.domain.Interview;
@@ -111,6 +112,27 @@ public class Answer extends BaseEntity {
      * @return Answer 객체
      */
     public static Answer of(AnswerCreateCommand command, String feedback) {
+        String[] texts = splitAndTrimText(feedback);
+
+        String userAnswer = texts[0];
+        AnswerStatus status = AnswerStatus.valueOf(texts[1]);
+        String AIAnswer = texts[2];
+        String trimmedVideoURL = removeQueryParams(command.videoURL());
+
+        return Answer.builder()
+            .questionId(command.questionId())
+            .memberId(command.memberId())
+            .interviewId(command.interviewId())
+            .userAnswer(userAnswer)
+            .videoURL(trimmedVideoURL)
+            .runningTime(command.time())
+            .isUnderstood(false)
+            .status(status)
+            .AIAnswer(AIAnswer)
+            .build();
+    }
+
+    public static Answer of(AnswerCreateAsyncCommand command, String feedback) {
         String[] texts = splitAndTrimText(feedback);
 
         String userAnswer = texts[0];

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/AnswerTask.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/AnswerTask.java
@@ -1,0 +1,106 @@
+package com.blooming.inpeak.answer.domain;
+
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import com.blooming.inpeak.common.base.BaseEntity;
+import com.blooming.inpeak.common.error.exception.BadRequestException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "answer_tasks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnswerTask extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = true)
+    private Long answerId;
+
+    @Column(nullable = false)
+    private Long questionId;
+
+    @Column(nullable = false)
+    private String questionContent;
+
+    @Column(nullable = false)
+    private Long interviewId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private String audioFileUrl;
+
+    @Column(nullable = true)
+    private String videoUrl;
+
+    @Column(nullable = false)
+    private Long time; // 답변 시간 (초 또는 ms)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnswerTaskStatus status;
+
+    @Builder
+    private AnswerTask(Long id, Long answerId, Long questionId, Long interviewId,
+        Long memberId, String audioFileUrl, String videoUrl, Long time,
+        AnswerTaskStatus status, String questionContent) {
+        this.id = id;
+        this.answerId = answerId;
+        this.questionId = questionId;
+        this.interviewId = interviewId;
+        this.memberId = memberId;
+        this.questionContent = questionContent;
+        this.audioFileUrl = removeQueryParams(audioFileUrl);
+        this.videoUrl = removeQueryParams(videoUrl);
+        this.time = time;
+        this.status = status;
+    }
+
+    public static AnswerTask createAnswerTask(AnswerCreateAsyncCommand command, String questionContent) {
+        return AnswerTask.builder()
+            .questionId(command.questionId())
+            .interviewId(command.interviewId())
+            .memberId(command.memberId())
+            .questionContent(questionContent)
+            .audioFileUrl(command.audioURL())
+            .videoUrl(command.videoURL())
+            .time(command.time())
+            .status(AnswerTaskStatus.WAITING)
+            .build();
+    }
+
+    public void markSuccess(Long answerId) {
+        this.status = AnswerTaskStatus.SUCCESS;
+        this.answerId = answerId;
+    }
+
+    private static String removeQueryParams(String url) {
+        if (url == null) return null;
+        return url.split("\\?")[0];
+    }
+
+    public void markFailed() {
+        this.status = AnswerTaskStatus.FAILED;
+    }
+
+    public void retry() {
+        if (this.status != AnswerTaskStatus.FAILED) {
+            throw new BadRequestException("작업 상태가 실패 상태가 아닙니다. 현재 상태: " + this.status);
+        }
+
+        this.status = AnswerTaskStatus.WAITING;
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/AnswerTaskStatus.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/AnswerTaskStatus.java
@@ -1,0 +1,18 @@
+package com.blooming.inpeak.answer.domain;
+
+public enum AnswerTaskStatus {
+    WAITING("메시지만 보낸 상태"),
+    SUCCESS("Answer 생성 완료"),
+    FAILED("GPT 또는 처리 오류"),
+    ;
+
+    private final String message;
+
+    AnswerTaskStatus(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/AnswerCreateAsyncCommand.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/AnswerCreateAsyncCommand.java
@@ -1,0 +1,26 @@
+package com.blooming.inpeak.answer.dto.command;
+
+import com.blooming.inpeak.answer.domain.AnswerTask;
+import lombok.Builder;
+
+@Builder
+public record AnswerCreateAsyncCommand(
+    String audioURL,
+    Long time,
+    Long memberId,
+    Long questionId,
+    Long interviewId,
+    String videoURL
+){
+    public static AnswerCreateAsyncCommand from (AnswerTask answerTask) {
+        return AnswerCreateAsyncCommand
+            .builder()
+            .audioURL(answerTask.getAudioFileUrl())
+            .time(answerTask.getTime())
+            .memberId(answerTask.getMemberId())
+            .questionId(answerTask.getQuestionId())
+            .interviewId(answerTask.getInterviewId())
+            .videoURL(answerTask.getVideoUrl())
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/GptMessage.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/GptMessage.java
@@ -1,0 +1,6 @@
+package com.blooming.inpeak.answer.dto.command;
+
+public record GptMessage(
+    String role,
+    Object content
+){ }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerCreateRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerCreateRequest.java
@@ -1,0 +1,29 @@
+package com.blooming.inpeak.answer.dto.request;
+
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerCreateRequest(
+        @NotNull
+        String audioURL,
+        @NotNull
+        Long time,
+        @NotNull
+        Long questionId,
+        @NotNull
+        Long interviewId,
+        String videoURL
+    ){
+
+    public AnswerCreateAsyncCommand toAsyncCommand(Long memberId) {
+        return AnswerCreateAsyncCommand
+            .builder()
+            .audioURL(audioURL)
+            .time(time)
+            .memberId(memberId)
+            .questionId(questionId)
+            .interviewId(interviewId)
+            .videoURL(videoURL)
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/GptRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/GptRequest.java
@@ -1,6 +1,6 @@
 package com.blooming.inpeak.answer.dto.request;
 
-import com.blooming.inpeak.answer.dto.command.Message;
+import com.blooming.inpeak.answer.dto.command.GptMessage;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
@@ -8,17 +8,17 @@ import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record GPTRequest(
+public record GptRequest(
     String model,
-    List<Message> messages,
+    List<GptMessage> messages,
     int temperature,
     int maxTokens,
     int topP,
     int frequencyPenalty,
     int presencePenalty
 ) {
-    public static GPTRequest of(String model, List<Message> messages) {
-        return GPTRequest.builder()
+    public static GptRequest of(String model, List<GptMessage> messages) {
+        return GptRequest.builder()
             .model(model)
             .messages(messages)
             .temperature(1)

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerTaskRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerTaskRepository.java
@@ -1,0 +1,8 @@
+package com.blooming.inpeak.answer.repository;
+
+import com.blooming.inpeak.answer.domain.AnswerTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerTaskRepository extends JpaRepository<AnswerTask, Long> {
+
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncProcessor.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncProcessor.java
@@ -1,0 +1,39 @@
+package com.blooming.inpeak.answer.service;
+
+import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.domain.AnswerTask;
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerAsyncProcessor {
+
+    private final AnswerTaskRepository answerTaskRepository;
+    private final AnswerManagerService answerManagerService;
+    private final GptAsyncService gptAsyncService;
+    private final AnswerPresignedUrlService answerPresignedUrlService;
+
+    @Async("gptExecutor")
+    public CompletableFuture<Void> processAnswerTaskAsync(AnswerTask task) {
+        AnswerCreateAsyncCommand command = AnswerCreateAsyncCommand.from(task);
+        byte[] audioBytes = answerPresignedUrlService.downloadAudioFromS3(command.audioURL());
+
+        try {
+            String feedback = gptAsyncService.makeGptAsyncResponse(audioBytes, task.getQuestionContent());
+            Answer answer = answerManagerService.generateAnswer(command, feedback);
+            task.markSuccess(answer.getId());
+
+        } catch (Exception e) {
+            task.markFailed();
+        } finally {
+            answerTaskRepository.save(task);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
@@ -1,0 +1,59 @@
+package com.blooming.inpeak.answer.service;
+
+import com.blooming.inpeak.answer.domain.AnswerTask;
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
+import com.blooming.inpeak.common.error.exception.NotFoundException;
+import com.blooming.inpeak.question.domain.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerAsyncService {
+
+    private final AnswerManagerService answerManagerService;
+    private final AnswerTaskRepository answerTaskRepository;
+    private final AnswerAsyncProcessor answerAsyncProcessor;
+
+    private static final String ANSWER_TASK_TOPIC = "answer-task-topic";
+
+    /**
+     * 비동기 답변 생성 요청 메서드
+     *
+     * @param command 답변 생성 명령어
+     * @return 생성된 답변 작업 ID
+     */
+    @Transactional
+    public Long requestAsyncAnswerCreation(AnswerCreateAsyncCommand command) {
+
+        Question question = answerManagerService.validateAndGetQuestion(command);
+        AnswerTask newTask = AnswerTask.createAnswerTask(command, question.getContent());
+        AnswerTask savedTask = answerTaskRepository.save(newTask);
+
+        // 비동기 작업 요청
+        answerAsyncProcessor.processAnswerTaskAsync(savedTask);
+
+        return savedTask.getId();
+    }
+
+    /**
+     * 답변 작업 재시도 메서드
+     *
+     * @param taskId   작업 ID
+     * @param memberId 사용자 ID
+     */
+    @Transactional
+    public void retryAnswerTask(Long taskId, Long memberId) {
+        AnswerTask task = answerTaskRepository.findById(taskId)
+            .orElseThrow(() -> new NotFoundException("AnswerTask 없음. taskId=" + taskId));
+
+        // 작업 상태를 대기 상태로 변경
+        task.retry();
+        answerTaskRepository.save(task);
+
+        // 비동기 작업 요청
+        //kafkaTemplate.send(ANSWER_TASK_TOPIC, new AnswerTaskMessage(task.getId()));
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerManagerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerManagerService.java
@@ -1,0 +1,43 @@
+package com.blooming.inpeak.answer.service;
+
+import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import com.blooming.inpeak.answer.repository.AnswerRepository;
+import com.blooming.inpeak.common.error.exception.ConflictException;
+import com.blooming.inpeak.common.error.exception.NotFoundException;
+import com.blooming.inpeak.member.service.MemberStatisticsService;
+import com.blooming.inpeak.question.domain.Question;
+import com.blooming.inpeak.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerManagerService {
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final MemberStatisticsService memberStatisticsService;
+
+    @Transactional(readOnly = true)
+    public Question validateAndGetQuestion(AnswerCreateAsyncCommand command) {
+        if (answerRepository.existsByInterviewIdAndQuestionId(command.interviewId(),
+            command.questionId())) {
+            throw new ConflictException("이미 답변이 존재하는 질문입니다.");
+        }
+
+        return questionRepository.findById(command.questionId())
+            .orElseThrow(() -> new NotFoundException("해당 질문이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public Answer generateAnswer(AnswerCreateAsyncCommand command, String feedback) {
+        Answer answer = Answer.of(command, feedback);
+        answerRepository.save(answer);
+
+        // 회원 통계 업데이트
+        memberStatisticsService.updateStatistics(command.memberId(), answer.getStatus());
+
+        return answer;
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -42,7 +42,7 @@ public class AnswerService {
 
     private final AnswerRepository answerRepository;
     private final AnswerRepositoryCustom answerRepositoryCustom;
-    private final GPTService gptService;
+    private final GptService gptService;
     private final QuestionRepository questionRepository;
     private final InterviewRepository interviewRepository;
     private final MemberStatisticsService memberStatisticsService;
@@ -144,7 +144,7 @@ public class AnswerService {
         Question question = questionRepository.findById(command.questionId())
             .orElseThrow(() -> new NotFoundException("해당 질문이 존재하지 않습니다."));
 
-        String feedback = gptService.makeGPTResponse(command.audioFile(), question.getContent());
+        String feedback = gptService.makeGptResponse(command.audioFile(), question.getContent());
 
         Answer answer = Answer.of(command, feedback);
         answerRepository.save(answer);

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/GptAsyncService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/GptAsyncService.java
@@ -1,14 +1,14 @@
 package com.blooming.inpeak.answer.service;
 
-import com.blooming.inpeak.answer.dto.command.Message;
-import com.blooming.inpeak.answer.dto.request.GPTRequest;
+import com.blooming.inpeak.answer.dto.command.GptMessage;
+import com.blooming.inpeak.answer.dto.request.GptRequest;
 import com.blooming.inpeak.answer.dto.response.GPTResponse;
-import com.blooming.inpeak.common.error.exception.EncodingException;
-import java.io.IOException;
+import com.blooming.inpeak.common.error.exception.GptApiException;
 import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ByteArrayResource;
@@ -21,11 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-public class GPTService {
+@Slf4j
+public class GptAsyncService {
 
     @Value("${openai.models.text}")
     private String model;
@@ -45,24 +45,24 @@ public class GPTService {
     private final RestTemplate restTemplate;
     private final RestTemplate whisperRestTemplate;
 
-    public String transcribe(MultipartFile audioFile) {
+    public String transcribe(byte[] audioFile) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.setBearerAuth(openAiKey);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("model", "whisper-1");
+        body.add("file", new ByteArrayResource(audioFile) {
+            @Override
+            @NonNull
+            public String getFilename() {
+                return "audio.wav";
+            }
+        });
+
+        HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+
         try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-            headers.setBearerAuth(openAiKey);
-
-            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("model", "whisper-1");
-            body.add("file", new ByteArrayResource(audioFile.getBytes()) {
-                @Override
-                @NonNull
-                public String getFilename() {
-                    return audioFile.getOriginalFilename();
-                }
-            });
-
-            HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
-
             ResponseEntity<Map<String, Object>> response = whisperRestTemplate.exchange(
                 "https://api.openai.com/v1/audio/transcriptions",
                 HttpMethod.POST,
@@ -71,9 +71,10 @@ public class GPTService {
                 }
             );
 
+            log.info("STT 응답처리 성공: {}", response.getBody());
             return (String) response.getBody().get("text");
-        } catch (IOException e) {
-            throw new EncodingException("Failed to transcribe audio file");
+        } catch (Exception e) {
+            throw new GptApiException("STT 처리 실패");
         }
     }
 
@@ -84,21 +85,27 @@ public class GPTService {
      * @param questionContent 면접 질문
      * @return 면접 질문에 대한 답변
      */
-    public String makeGPTResponse(MultipartFile audioFile, String questionContent) {
+    public String makeGptAsyncResponse(byte[] audioFile, String questionContent) {
         String transcribedText = transcribe(audioFile);
 
-        GPTRequest request = GPTRequest.of(model,
+        GptRequest request = GptRequest.of(model,
             makePromptMessages(transcribedText, questionContent));
 
-        GPTResponse response = restTemplate.postForObject(apiUrl, request, GPTResponse.class);
+        try {
+            GPTResponse response = restTemplate.postForObject(apiUrl, request, GPTResponse.class);
 
-        return (String) response.choices().get(0).message().content();
+            log.info("GPT 응답 생성 성공: {}", response);
+            return (String) response.choices().get(0).message().content();
+        } catch (Exception e) {
+            log.error("GPT 응답 생성 실패: {}", e.getMessage(), e);
+            throw new GptApiException("GPT 응답 생성 실패");
+        }
     }
 
-    private List<Message> makePromptMessages(String text, String questionContent) {
+    private List<GptMessage> makePromptMessages(String text, String questionContent) {
         return List.of(
-            new Message("system", prompt),
-            new Message("user", List.of(
+            new GptMessage("system", prompt),
+            new GptMessage("user", List.of(
                 Map.of("type", "text", "text", "면접 질문: " + questionContent),
                 Map.of("type", "text", "text", "지원자의 답변: " + text)
             ))

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/GptService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/GptService.java
@@ -1,0 +1,107 @@
+package com.blooming.inpeak.answer.service;
+
+import com.blooming.inpeak.answer.dto.command.GptMessage;
+import com.blooming.inpeak.answer.dto.request.GptRequest;
+import com.blooming.inpeak.answer.dto.response.GPTResponse;
+import com.blooming.inpeak.common.error.exception.EncodingException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class GptService {
+
+    @Value("${openai.models.text}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Value("${openai.prompt}")
+    private String prompt;
+
+    @Value("${openai.models.format}")
+    private String format;
+
+    @Value("${openai.api.key}")
+    private String openAiKey;
+
+    private final RestTemplate restTemplate;
+    private final RestTemplate whisperRestTemplate;
+
+    public String transcribe(MultipartFile audioFile) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            headers.setBearerAuth(openAiKey);
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("model", "whisper-1");
+            body.add("file", new ByteArrayResource(audioFile.getBytes()) {
+                @Override
+                @NonNull
+                public String getFilename() {
+                    return audioFile.getOriginalFilename();
+                }
+            });
+
+            HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+
+            ResponseEntity<Map<String, Object>> response = whisperRestTemplate.exchange(
+                "https://api.openai.com/v1/audio/transcriptions",
+                HttpMethod.POST,
+                request,
+                new ParameterizedTypeReference<>() {
+                }
+            );
+
+            return (String) response.getBody().get("text");
+        } catch (IOException e) {
+            throw new EncodingException("Failed to transcribe audio file");
+        }
+    }
+
+    /**
+     * GPT API를 이용하여 지원자의 음성 데이터를 텍스트로 변환하고, 면접 질문에 대한 답변을 생성한다.
+     *
+     * @param audioFile       지원자의 음성 데이터
+     * @param questionContent 면접 질문
+     * @return 면접 질문에 대한 답변
+     */
+    public String makeGptResponse(MultipartFile audioFile, String questionContent) {
+        String transcribedText = transcribe(audioFile);
+
+        GptRequest request = GptRequest.of(model,
+            makePromptMessages(transcribedText, questionContent));
+
+        GPTResponse response = restTemplate.postForObject(apiUrl, request, GPTResponse.class);
+
+        return (String) response.choices().get(0).message().content();
+    }
+
+    private List<GptMessage> makePromptMessages(String text, String questionContent) {
+        return List.of(
+            new GptMessage("system", prompt),
+            new GptMessage("user", List.of(
+                Map.of("type", "text", "text", "면접 질문: " + questionContent),
+                Map.of("type", "text", "text", "지원자의 답변: " + text)
+            ))
+        );
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/AsyncConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.blooming.inpeak.common.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "gptExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);       // 기본 스레드 수
+        executor.setMaxPoolSize(10);       // 최대 스레드 수
+        executor.setQueueCapacity(100);    // 대기 큐
+        executor.setThreadNamePrefix("GPT-Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/DownloadFailureException.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/DownloadFailureException.java
@@ -1,0 +1,7 @@
+package com.blooming.inpeak.common.error.exception;
+
+public class DownloadFailureException extends RuntimeException {
+    public DownloadFailureException(String message) {
+        super(message);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/GptApiException.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/GptApiException.java
@@ -1,0 +1,9 @@
+package com.blooming.inpeak.common.error.exception;
+
+public class GptApiException extends RuntimeException {
+
+    public GptApiException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #8 

## 📝 작업 내용
- GPT 응답 생성을 기존 직렬 처리 방식에서 `CompletableFuture + @Async` 기반 병렬 처리 방식으로 개선
- `AnswerAsyncProcessor` 클래스를 새로 생성하고, GPT 응답 생성 → Answer 저장까지의 흐름에 비동기화 적용
- 프론트엔드와의 기존 API 호출 흐름 호환성을 유지하기 위해, 직렬 로직은 유지한 채 내부 로직만 비동기화
  - `AnswerContoller`에 `/v2/create` 경로로 병렬 처리용 엔드포인트 추가
