### PR TITLE
AnswerTask 상태 조회 및 재시도 기능을 추가합니다

### DIFF
--- a/inpeak/init-scripts/01-ddl.sql
+++ b/inpeak/init-scripts/01-ddl.sql
@@ -30,8 +30,6 @@ CREATE TABLE members (
                          id BIGINT PRIMARY KEY AUTO_INCREMENT,
                          kakao_id BIGINT,
                          nickname VARCHAR(255) NOT NULL UNIQUE,
-                         total_question_count BIGINT,
-                         correct_answer_count BIGINT,
                          provider VARCHAR(50) NOT NULL,
                          registration_status VARCHAR(50) NOT NULL,
                          kakao_email VARCHAR(255) NOT NULL,

--- a/inpeak/init-scripts/02-data.sql
+++ b/inpeak/init-scripts/02-data.sql
@@ -21,15 +21,14 @@ START TRANSACTION;
 -- 1. 회원 데이터
 -- -------------------------------
 INSERT INTO members
-(id, correct_answer_count, created_at, total_question_count, updated_at,
- kakao_id, nickname, provider, registration_status, kakao_email)
+(id, created_at,  updated_at, kakao_id, nickname, provider, registration_status, kakao_email)
 VALUES
-    (1, 0, NOW(), 0, NOW(), 1, "test1", "KAKAO", "COMPLETED", "test1@test.com"),
-    (2, 0, NOW(), 0, NOW(), 2, "test2", "KAKAO", "INITIATED", "test2@test.com"),
-    (3, 0, NOW(), 0, NOW(), 3, "test3", "KAKAO", "COMPLETED", "test3@test.com"),
-    (4, 0, NOW(), 0, NOW(), 4, "test4", "KAKAO", "INITIATED", "test4@test.com"),
-    (5, 0, NOW(), 0, NOW(), 5, "test5", "KAKAO", "COMPLETED", "test5@test.com"),
-    (6, 0, NOW(), 0, NOW(), 6, "test6", "KAKAO", "INITIATED", "test6@test.com");
+    (1, NOW(), NOW(), 1, "test1", "KAKAO", "COMPLETED", "test1@test.com"),
+    (2, NOW(), NOW(), 2, "test2", "KAKAO", "INITIATED", "test2@test.com"),
+    (3, NOW(), NOW(), 3, "test3", "KAKAO", "COMPLETED", "test3@test.com"),
+    (4, NOW(), NOW(), 4, "test4", "KAKAO", "INITIATED", "test4@test.com"),
+    (5, NOW(), NOW(), 5, "test5", "KAKAO", "COMPLETED", "test5@test.com"),
+    (6, NOW(), NOW(), 6, "test6", "KAKAO", "INITIATED", "test6@test.com");
 
 SELECT CONCAT('회원 데이터: ', COUNT(*), '개 행') AS message FROM members;
 

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -115,17 +115,6 @@ public class AnswerController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/v2/create")
-    public ResponseEntity<Long> createAnswer(
-        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-        @RequestBody AnswerCreateRequest request
-    ) {
-        AnswerCreateAsyncCommand command = request.toAsyncCommand(memberPrincipal.id());
-        Long response = answerAsyncService.requestAsyncAnswerCreation(command);
-
-        return ResponseEntity.ok(response);
-    }
-
     @PutMapping("/understood")
     public ResponseEntity<Void> updateUnderstood(
         @RequestBody UnderstoodUpdateRequest request,

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerControllerV2.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerControllerV2.java
@@ -1,0 +1,63 @@
+package com.blooming.inpeak.answer.controller;
+
+import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
+import com.blooming.inpeak.answer.dto.request.AnswerCreateRequest;
+import com.blooming.inpeak.answer.dto.response.AnswerByTaskResponse;
+import com.blooming.inpeak.answer.dto.response.AnswerDetailResponse;
+import com.blooming.inpeak.answer.service.AnswerAsyncService;
+import com.blooming.inpeak.answer.service.AnswerService;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/answer/v2")
+@RequiredArgsConstructor
+public class AnswerControllerV2 {
+
+    private final AnswerService answerService;
+    private final AnswerAsyncService answerAsyncService;
+
+    @PostMapping("/create")
+    public ResponseEntity<Long> createAnswer(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @RequestBody AnswerCreateRequest request
+    ) {
+        AnswerCreateAsyncCommand command = request.toAsyncCommand(memberPrincipal.id());
+        Long response = answerAsyncService.requestAsyncAnswerCreation(command);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<AnswerByTaskResponse> findAnswerByTaskId(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @PathVariable Long taskId) {
+        return answerService.findAnswerByTaskId(taskId, memberPrincipal.id());
+    }
+
+    @GetMapping("/{answerId}")
+    public ResponseEntity<AnswerDetailResponse> getAnswerById(
+        @PathVariable Long answerId,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal
+    ) {
+        AnswerDetailResponse response = answerService.getAnswerById(answerId, memberPrincipal.id());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/tasks/{taskId}/retry")
+    public ResponseEntity<Void> retryAnswerTask(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @PathVariable Long taskId
+    ) {
+        answerAsyncService.retryAnswerTask(taskId, memberPrincipal.id());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerByTaskResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerByTaskResponse.java
@@ -1,0 +1,18 @@
+package com.blooming.inpeak.answer.dto.response;
+
+public record AnswerByTaskResponse(
+    Long taskId,
+    String status,
+    Long answerId) {
+    public static AnswerByTaskResponse waiting(Long taskId) {
+        return new AnswerByTaskResponse(taskId, "WAITING", null);
+    }
+
+    public static AnswerByTaskResponse failed(Long taskId) {
+        return new AnswerByTaskResponse(taskId, "FAILED", null);
+    }
+
+    public static AnswerByTaskResponse success(Long taskId, Long answerId) {
+        return new AnswerByTaskResponse(taskId, "SUCCESS", answerId);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
@@ -5,6 +5,7 @@ import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
 import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
 import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.question.domain.Question;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,7 @@ public class AnswerAsyncService {
         AnswerTask savedTask = answerTaskRepository.save(newTask);
 
         // 비동기 작업 요청
-        answerAsyncProcessor.processAnswerTaskAsync(savedTask);
+        answerAsyncProcessor.handleTaskAsync(savedTask);
 
         return savedTask.getId();
     }
@@ -51,9 +52,9 @@ public class AnswerAsyncService {
 
         // 작업 상태를 대기 상태로 변경
         task.retry();
-        answerTaskRepository.save(task);
+        AnswerTask savedTask = answerTaskRepository.save(task);
 
         // 비동기 작업 요청
-        //kafkaTemplate.send(ANSWER_TASK_TOPIC, new AnswerTaskMessage(task.getId()));
+        answerAsyncProcessor.handleTaskAsync(savedTask);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
@@ -61,8 +61,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             .kakaoId(kakaoId)
             .nickname(uniqueNickname)
             .provider(OAuth2Provider.KAKAO)
-            .totalQuestionCount(0L)
-            .correctAnswerCount(0L)
             .registrationStatus(RegistrationStatus.INITIATED)
             .kakaoEmail(kakaoEmail)
             .build();

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -30,12 +30,6 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
-    @Column
-    private Long totalQuestionCount;
-
-    @Column
-    private Long correctAnswerCount;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OAuth2Provider provider;
@@ -48,32 +42,13 @@ public class Member extends BaseEntity {
     private String kakaoEmail;
 
     @Builder
-    private Member(
+    public Member(
         Long id,
-        Long kakaoId, String nickname, Long totalQuestionCount,
-        Long correctAnswerCount, OAuth2Provider provider,
+        Long kakaoId, String nickname, OAuth2Provider provider,
         RegistrationStatus registrationStatus, String kakaoEmail
     ) {
         this.id = id;
         this.kakaoId = kakaoId;
-        this.nickname = nickname;
-        this.totalQuestionCount = totalQuestionCount;
-        this.correctAnswerCount = correctAnswerCount;
-        this.provider = provider;
-        this.registrationStatus =
-            registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED;
-        this.kakaoEmail = kakaoEmail;
-    }
-
-    // 테스트 파일에서 사용할 생성자
-    @Builder(access = AccessLevel.PRIVATE)
-    public Member(
-        Long id, Long kakaoId, String nickname,
-        OAuth2Provider provider, RegistrationStatus registrationStatus,
-        String kakaoEmail
-    ) {
-        this.id = id;
-        this.kakaoId= kakaoId;
         this.nickname = nickname;
         this.provider = provider;
         this.registrationStatus =

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/MemberPrincipal.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/MemberPrincipal.java
@@ -32,8 +32,6 @@ public record MemberPrincipal(
             .kakaoId(member.getKakaoId())
             .nickname(member.getNickname())
             .provider(member.getProvider())
-            .totalQuestionCount(member.getTotalQuestionCount())
-            .correctAnswerCount(member.getCorrectAnswerCount())
             .authorities(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
             .attributes(attributes)
             .build();

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
@@ -75,8 +75,6 @@ class CustomOAuth2UserServiceTest {
             .kakaoId(kakaoId)
             .nickname("기존회원")
             .provider(OAuth2Provider.KAKAO)
-            .totalQuestionCount(0L)
-            .correctAnswerCount(0L)
             .build();
 
         // 테스트 데이터 설정
@@ -145,8 +143,6 @@ class CustomOAuth2UserServiceTest {
             .kakaoId(kakaoId)
             .nickname(generatedNickname)
             .provider(OAuth2Provider.KAKAO)
-            .totalQuestionCount(0L)
-            .correctAnswerCount(0L)
             .kakaoEmail(testEmail)
             .build();
 

--- a/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
@@ -35,8 +35,6 @@ class MemberRepositoryTest extends IntegrationTestSupport {
             .kakaoId(kakaoId)
             .nickname("테스트유저")
             .provider(OAuth2Provider.KAKAO)
-            .totalQuestionCount(0L)
-            .correctAnswerCount(0L)
             .kakaoEmail(testEmail)
             .build();
         memberRepository.save(member);
@@ -62,8 +60,6 @@ class MemberRepositoryTest extends IntegrationTestSupport {
             .kakaoId(kakaoId)
             .nickname(nickname)
             .provider(OAuth2Provider.KAKAO)
-            .totalQuestionCount(0L)
-            .correctAnswerCount(0L)
             .kakaoEmail(testEmail)
             .build();
         memberRepository.save(member);


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #10 

## 📝 작업 내용

- `AnswerTask` 상태(`WAITING`, `SUCCESS`, `FAILED`) 조회하는 기능 구현
  - 상태가 실패(`FAILED`)인 경우 내부적으로 재시도 1회 진행
- 실패(`FAILED`) 상태일 경우 별도의 수동 재시도 기능 구현
- 기존 직렬 처리 방식을 유지하면서 비동기 기능은 `AnswerControllerV2`로 분리
- `Member` 엔티티의 사용하지 않는 필드 제거
