### PR TITLE
회원 통계 업데이트 및 import 구문을 정리합니다

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,21 +1,9 @@
 package com.blooming.inpeak.answer.controller;
 
 import com.blooming.inpeak.answer.domain.AnswerStatus;
-import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
-import com.blooming.inpeak.answer.dto.command.AnswerCreateCommand;
-import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
-import com.blooming.inpeak.answer.dto.request.AnswerCreateRequest;
-import com.blooming.inpeak.answer.dto.request.AnswerSkipRequest;
-import com.blooming.inpeak.answer.dto.request.CommentUpdateRequest;
-import com.blooming.inpeak.answer.dto.request.CorrectAnswerFilterRequest;
-import com.blooming.inpeak.answer.dto.request.IncorrectAnswerFilterRequest;
-import com.blooming.inpeak.answer.dto.request.UnderstoodUpdateRequest;
-import com.blooming.inpeak.answer.dto.response.AnswerDetailResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerIDResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
-import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
-import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
+import com.blooming.inpeak.answer.dto.command.*;
+import com.blooming.inpeak.answer.dto.request.*;
+import com.blooming.inpeak.answer.dto.response.*;
 import com.blooming.inpeak.answer.service.AnswerAsyncService;
 import com.blooming.inpeak.answer.service.AnswerPresignedUrlService;
 import com.blooming.inpeak.answer.service.AnswerService;
@@ -41,8 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class AnswerController {
 
     private final AnswerService answerService;
-    private final AnswerPresignedUrlService answerPresignedUrlService;
-    private final AnswerAsyncService answerAsyncService;
 
     @PostMapping("/skip")
     public ResponseEntity<AnswerIDResponse> skipAnswer(

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerControllerV2.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerControllerV2.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/answer/v2")
+@RequestMapping("/api/v2/answer")
 @RequiredArgsConstructor
 public class AnswerControllerV2 {
 
@@ -50,14 +50,5 @@ public class AnswerControllerV2 {
     ) {
         AnswerDetailResponse response = answerService.getAnswerById(answerId, memberPrincipal.id());
         return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/tasks/{taskId}/retry")
-    public ResponseEntity<Void> retryAnswerTask(
-        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-        @PathVariable Long taskId
-    ) {
-        answerAsyncService.retryAnswerTask(taskId, memberPrincipal.id());
-        return ResponseEntity.ok().build();
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerAsyncService.java
@@ -3,9 +3,7 @@ package com.blooming.inpeak.answer.service;
 import com.blooming.inpeak.answer.domain.AnswerTask;
 import com.blooming.inpeak.answer.dto.command.AnswerCreateAsyncCommand;
 import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
-import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.question.domain.Question;
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +15,6 @@ public class AnswerAsyncService {
     private final AnswerManagerService answerManagerService;
     private final AnswerTaskRepository answerTaskRepository;
     private final AnswerAsyncProcessor answerAsyncProcessor;
-
-    private static final String ANSWER_TASK_TOPIC = "answer-task-topic";
 
     /**
      * 비동기 답변 생성 요청 메서드
@@ -37,24 +33,5 @@ public class AnswerAsyncService {
         answerAsyncProcessor.handleTaskAsync(savedTask);
 
         return savedTask.getId();
-    }
-
-    /**
-     * 답변 작업 재시도 메서드
-     *
-     * @param taskId   작업 ID
-     * @param memberId 사용자 ID
-     */
-    @Transactional
-    public void retryAnswerTask(Long taskId, Long memberId) {
-        AnswerTask task = answerTaskRepository.findById(taskId)
-            .orElseThrow(() -> new NotFoundException("AnswerTask 없음. taskId=" + taskId));
-
-        // 작업 상태를 대기 상태로 변경
-        task.retry();
-        AnswerTask savedTask = answerTaskRepository.save(task);
-
-        // 비동기 작업 요청
-        answerAsyncProcessor.handleTaskAsync(savedTask);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -1,23 +1,9 @@
 package com.blooming.inpeak.answer.service;
 
-import com.blooming.inpeak.answer.domain.Answer;
-import com.blooming.inpeak.answer.domain.AnswerStatus;
-import com.blooming.inpeak.answer.domain.AnswerTask;
-import com.blooming.inpeak.answer.domain.AnswerTaskStatus;
-import com.blooming.inpeak.answer.dto.command.AnswerCreateCommand;
-import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
-import com.blooming.inpeak.answer.dto.response.AnswerByTaskResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerDetailResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerIDResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
-import com.blooming.inpeak.answer.dto.response.AnswerResponse;
-import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
-import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
-import com.blooming.inpeak.answer.dto.response.RecentAnswerResponse;
-import com.blooming.inpeak.answer.repository.AnswerRepository;
-import com.blooming.inpeak.answer.repository.AnswerRepositoryCustom;
-import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
+import com.blooming.inpeak.answer.domain.*;
+import com.blooming.inpeak.answer.dto.command.*;
+import com.blooming.inpeak.answer.dto.response.*;
+import com.blooming.inpeak.answer.repository.*;
 import com.blooming.inpeak.common.error.exception.ConflictException;
 import com.blooming.inpeak.common.error.exception.EncodingException;
 import com.blooming.inpeak.common.error.exception.ForbiddenException;
@@ -71,6 +57,9 @@ public class AnswerService {
 
         Answer skippedAnswer = Answer.ofSkipped(memberId, questionId, interviewId);
         answerRepository.save(skippedAnswer);
+
+        // 회원 통계 업데이트
+        memberStatisticsService.updateStatistics(memberId, skippedAnswer.getStatus());
 
         return new AnswerIDResponse(skippedAnswer.getId());
     }

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
@@ -11,10 +11,11 @@ import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerResponse;
 import com.blooming.inpeak.answer.repository.AnswerRepository;
-import com.blooming.inpeak.answer.repository.AnswerRepositoryCustom;
 import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
+import com.blooming.inpeak.member.domain.MemberStatistics;
+import com.blooming.inpeak.member.repository.MemberStatisticsRepository;
 import com.blooming.inpeak.question.domain.Question;
 import com.blooming.inpeak.question.domain.QuestionType;
 import com.blooming.inpeak.question.repository.QuestionRepository;
@@ -37,9 +38,6 @@ class AnswerServiceTest extends IntegrationTestSupport {
     private AnswerRepository answerRepository;
 
     @Autowired
-    private AnswerRepositoryCustom answerRepositoryCustom;
-
-    @Autowired
     private QuestionRepository questionRepository;
 
     @Autowired
@@ -47,6 +45,9 @@ class AnswerServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private AnswerService answerService;
+
+    @Autowired
+    private MemberStatisticsRepository memberStatisticsRepository;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -67,18 +68,6 @@ class AnswerServiceTest extends IntegrationTestSupport {
             .isUnderstood(isUnderstood)
             .status(status)
             .build());
-    }
-
-    private Answer createAnswerEntity(Long memberId, Long questionId, Long interviewId, AnswerStatus status) {
-        return Answer.builder()
-            .questionId(questionId)
-            .memberId(memberId)
-            .interviewId(interviewId)
-            .userAnswer("스프링 답변1")
-            .runningTime(120L)
-            .isUnderstood(false)
-            .status(status)
-            .build();
     }
 
     @DisplayName("저장된 데이터를 기반으로 올바른 응답을 반환해야 한다")
@@ -137,6 +126,8 @@ class AnswerServiceTest extends IntegrationTestSupport {
             .getId();
         Question question = questionRepository.save(
             Question.of("자바의 GC 동작 방식", QuestionType.SPRING, "모법 답변"));
+
+        memberStatisticsRepository.save(MemberStatistics.of(memberId));
 
         // when
         answerService.skipAnswer(memberId, question.getId(), interviewId);


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #12 

## 📝 작업 내용

- 답변 스킵 시 회원 통계 업데이트 추가
- `AnswerControllerV2`의 prefix 수정
- 비동기 재시도 기능 삭제
- 사용하지 않는 import 구문을 정리