### PR TITLE
캘린더 API 빈 데이터 응답을 404에서 204 No Content로 변경합니다

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -7,6 +7,7 @@ import com.blooming.inpeak.answer.repository.*;
 import com.blooming.inpeak.common.error.exception.ConflictException;
 import com.blooming.inpeak.common.error.exception.EncodingException;
 import com.blooming.inpeak.common.error.exception.ForbiddenException;
+import com.blooming.inpeak.common.error.exception.NoContentException;
 import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
@@ -96,15 +97,15 @@ public class AnswerService {
         List<Answer> answers = answerRepository.findAnswersByMemberAndDate(memberId, date);
 
         if (answers.isEmpty()) {
-            // 🔍 인터뷰는 존재하지만 답변이 없는 케이스 확인을 위해 인터뷰만 따로 조회
+            // 인터뷰는 존재하지만 답변이 없는 케이스 확인을 위해 인터뷰만 따로 조회
             Interview interview = interviewRepository.findByMemberIdAndStartDate(memberId, date)
-                .orElseThrow(() -> new NotFoundException("해당 날짜에 진행된 인터뷰가 없습니다."));
+                .orElseThrow(() -> new NoContentException("해당 날짜에 진행된 인터뷰가 없습니다."));
 
-            // 🔴 인터뷰는 있지만 답변이 없음
+            // 인터뷰는 있지만 답변이 없음
             throw new ConflictException("해당 인터뷰에 대한 답변이 존재하지 않습니다.");
         }
 
-        // ✅ 인터뷰도 있고, 답변도 있음
+        // 인터뷰도 있고, 답변도 있음
         Interview interview = answers.get(0).getInterview(); // answer가 있으므로 get(0) 안전
         return InterviewWithAnswersResponse.from(interview, answers);
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorCode.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     CONFLICT("CONFLICT", "요청이 서버 상태와 충돌했습니다.", 409),
 
     // 500 Internal Server Error
-    ENCODING_FAILED("ENCODING_FAILED", "인코딩에 실패했습니다.", 500);
+    ENCODING_FAILED("ENCODING_FAILED", "인코딩에 실패했습니다.", 500),
+
+    // 204 No Content
+    NO_CONTENT("NO_CONTENT", "요청은 성공했지만 반환할 데이터가 없습니다.", 204);
 
     private final String code;
     private final String message;

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorHandlingController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorHandlingController.java
@@ -79,4 +79,11 @@ public class ErrorHandlingController {
         log.error("오디오 파일 인코딩 중 오류 발생: {}", e.getMessage());
         return buildError(ErrorCode.ENCODING_FAILED); // 혹은 적절한 에러 코드
     }
+
+    @ExceptionHandler(NoContentException.class)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    protected ErrorResponse handleNoContentException(NoContentException e) {
+        log.info("요청은 성공했지만 반환할 데이터가 없습니다: {}", e.getMessage());
+        return buildError(ErrorCode.NO_CONTENT);
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/NoContentException.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/exception/NoContentException.java
@@ -1,0 +1,7 @@
+package com.blooming.inpeak.common.error.exception;
+
+public class NoContentException extends RuntimeException {
+    public NoContentException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #14 

## 📝 작업 내용
- 캘린더 조회 API에서 데이터가 없을 때 404 대신 204 No Content 반환하도록 변경
